### PR TITLE
unload: add support for non-blocking delete

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 
 rust:
   - nightly-2018-07-24  # pinned toolchain for clippy
-  - 1.24.0              # minimum supported toolchain
+  - 1.26.0              # minimum supported toolchain
   - stable
   - beta
   - nightly
@@ -21,7 +21,7 @@ before_script:
     fi'
 
 script:
-  - cargo test
+  - cargo test --all-features
   - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "$CLIPPY_RUST_VERSION" ]]; then
-      cargo clippy -- -D warnings;
+      cargo clippy --all-features -- -D warnings;
     fi'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,23 @@ exclude = [
 ".travis.yml",
 ]
 
+[[example]]
+name = "async-unload"
+required-features = ["async"]
+
 [dependencies]
 # Private dependencies.
 libc = "0.2"
 # Public dependencies, exposed through library API.
 errno = "0.2"
 error-chain = {version = "0.12", default-features = false}
+futures = {version = "0.1", optional = true}
+
+[dev-dependencies]
+tokio = "0.1"
+
+[features]
+async = ["futures"]
 
 [package.metadata.release]
 sign-commit = true

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ fn load_modfile(fpath: &std::path::Path) -> errors::Result<()> {
 }
 ```
 
+## Features
+
+This crate supports the following optional features:
+ * `async`: this provides an `async_unload` method, using futures.
 
 ## License
 

--- a/examples/async-unload.rs
+++ b/examples/async-unload.rs
@@ -1,0 +1,33 @@
+//! A simple example showing how to (async) unload a module.
+//!
+//! It tries to unload a module by name in an asynchronous way,
+//! retrying for 5s before giving up if the module is busy.
+//!
+//! This is an example ONLY: do NOT panic/unwrap/assert
+//! in production code!
+
+extern crate likemod;
+extern crate tokio;
+
+use std::{process, time};
+use tokio::runtime::current_thread;
+use tokio::timer::timeout;
+
+fn main() {
+    // Get from cmdline the name of the module to unload.
+    let modname = std::env::args().nth(1).expect("missing module name");
+
+    // Assemble a future to unload the module, timing out after 5 seconds.
+    let modunload = likemod::ModUnloader::new().async_unload(&modname);
+    let tout = time::Duration::from_secs(15);
+    let fut = timeout::Timeout::new(modunload, tout);
+
+    // Run the future until completion.
+    if let Err(err) = current_thread::block_on_all(fut) {
+        eprintln!("FAILED: {:?}", err);
+        process::exit(1)
+    }
+
+    // Success!
+    println!("module '{}' unloaded.", modname);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,8 @@
 extern crate errno;
 #[macro_use]
 extern crate error_chain;
+#[cfg(feature = "async")]
+extern crate futures;
 extern crate libc;
 
 pub mod errors;


### PR DESCRIPTION
This adds full support for async unload, via futures.
As the `futures` crate is still evolving, this is gated behind an
`async` cargo feature.