### PR TITLE
unload: rate-limit async module unload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 
 rust:
   - nightly-2018-07-24  # pinned toolchain for clippy
-  - 1.26.0              # minimum supported toolchain
+  - 1.28.0              # minimum supported toolchain
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,10 @@ libc = "0.2"
 errno = "0.2"
 error-chain = {version = "0.12", default-features = false}
 futures = {version = "0.1", optional = true}
-
-[dev-dependencies]
-tokio = "0.1"
+tokio = {version = "0.1", optional = true}
 
 [features]
-async = ["futures"]
+async = ["futures", "tokio"]
 
 [package.metadata.release]
 sign-commit = true

--- a/examples/async-unload.rs
+++ b/examples/async-unload.rs
@@ -9,7 +9,7 @@
 extern crate likemod;
 extern crate tokio;
 
-use std::{process, time};
+use std::{num, process, time};
 use tokio::runtime::current_thread;
 use tokio::timer::timeout;
 
@@ -17,8 +17,10 @@ fn main() {
     // Get from cmdline the name of the module to unload.
     let modname = std::env::args().nth(1).expect("missing module name");
 
-    // Assemble a future to unload the module, timing out after 5 seconds.
-    let modunload = likemod::ModUnloader::new().async_unload(&modname);
+    // Assemble a future to unload the module; if busy,
+    // retry every 500ms and time out after 5 seconds.
+    let pause_ms = num::NonZeroU64::new(500).unwrap();
+    let modunload = likemod::ModUnloader::new().async_unload(&modname, pause_ms);
     let tout = time::Duration::from_secs(15);
     let fut = timeout::Timeout::new(modunload, tout);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ extern crate error_chain;
 #[cfg(feature = "async")]
 extern crate futures;
 extern crate libc;
+#[cfg(feature = "async")]
+extern crate tokio;
 
 pub mod errors;
 mod load;


### PR DESCRIPTION
This introduces a rate-limiting mechanism (fixed-interval pausing)
on async module unloading, as `delete_module(2)` has no direct
feedback events to get notified about readiness.