### PR TITLE
unload: fix method names and docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ disable-push = true
 pre-release-commit-message = "cargo: likemod release {{version}}"
 pro-release-commit-message = "cargo: version bump to {{version}}"
 tag-message = "likemod {{version}}"
+
+[package.metadata.docs.rs]
+features = ["async"]

--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ fn load_modfile(fpath: &std::path::Path) -> errors::Result<()> {
 }
 ```
 
+Some more examples are available under [examples](examples).
+
 ## Features
 
 This crate supports the following optional features:
- * `async`: this provides an `async_unload` method, using futures.
+ * `async`: this provides an `unload_async` method, using futures.
 
 ## License
 

--- a/examples/async-unload.rs
+++ b/examples/async-unload.rs
@@ -20,7 +20,7 @@ fn main() {
     // Assemble a future to unload the module; if busy,
     // retry every 500ms and time out after 5 seconds.
     let pause_ms = num::NonZeroU64::new(500).unwrap();
-    let modunload = likemod::ModUnloader::new().async_unload(&modname, pause_ms);
+    let modunload = likemod::ModUnloader::new().unload_async(&modname, pause_ms);
     let tout = time::Duration::from_secs(15);
     let fut = timeout::Timeout::new(modunload, tout);
 


### PR DESCRIPTION
This renames `unload_*` methods to be more consistent, and fixes
several documentation bits.