### PR TITLE
Fix finit_module syscall number for aarch64

### DIFF
--- a/src/nr.rs
+++ b/src/nr.rs
@@ -16,7 +16,7 @@ pub const FINIT_MODULE: i64 = 313;
 pub const DELETE_MODULE: i64 = 176;
 
 #[cfg(target_arch = "aarch64")]
-pub const FINIT_MODULE: i64 = 379;
+pub const FINIT_MODULE: i64 = 273;
 #[cfg(target_arch = "aarch64")]
 pub const DELETE_MODULE: i64 = 106;
 


### PR DESCRIPTION
According to [chromium docs](https://chromium.googlesource.com/chromiumos/docs/+/master/constants/syscalls.md) (any my kernel =)), the correct syscall number is 273